### PR TITLE
fix: backward-compat for ESM etherpad

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,9 +15,9 @@
 // permissions and limitations under the License.
 
 const authorManager = require('ep_etherpad-lite/node/db/AuthorManager');
-const log4js = require('ep_etherpad-lite/node_modules/log4js');
+const {createLogger} = require('ep_plugin_helpers/logger');
 
-const logger = log4js.getLogger('ep_headerauth');
+const logger = createLogger('ep_headerauth');
 let settings;
 
 exports.authenticate = (hookName, {req}, cb) => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ep_headerauth",
-  "version": "1.1.58",
+  "version": "1.1.59",
   "description": "Etherpad plugin to use a reverse proxy's HTTP headers for authentication.",
   "keywords": [
     "auth",
@@ -34,5 +34,8 @@
   },
   "engines": {
     "node": ">=18.0.0"
+  },
+  "dependencies": {
+    "ep_plugin_helpers": "^0.6.7"
   }
 }


### PR DESCRIPTION
This PR makes the plugin backward-compatible with the upcoming ESM etherpad branch (ether/etherpad#7605).

**Change:** Migrate log4js from `require("ep_etherpad-lite/node_modules/log4js")` to `ep_plugin_helpers/logger`

This change is **backward-compatible** with the current CJS etherpad release.